### PR TITLE
Add configuration for DXS Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,35 @@ UT Spot Autonomy Stack
 
 ## Joystick
 
+### Spektrum DXS SPMR1010
+
+![Spektrum DXS SPMR1010](https://user-images.githubusercontent.com/35668665/200152606-df0bd43d-4079-43bd-828d-2f3af82a2f95.jpg)
+
+* D Switch: Manual and Autonomous Control
+  * "0" (away): Autonomous Control
+  * "1" (neutral): Stop Robot
+  * "2" (back): Manual Control
+* A Button: Start/Stop `rosbag record`
+
+While in Manual Control:
+
+* Left Joystick: Yaw Control
+* Right Joystick: Translation Control
+* B Switch: Sit and Stand
+  * "0" (down): Sit
+  * "1" (neutral): Resume Manual Control
+  * "2" (up): Stand
+* F Switch: Speed Control
+  * "0" (away): Full Speed
+  * "1" (back): ~70% Speed (we cannot customize this)
+
+In addition to the "F" switch, the controller has a set of four "Trim" sliders
+that change the zero point of the joysticks (and thus their maximum and minimum
+values). These sliders emit audible chirps. A higher-pitched chirp is emitted
+when the neutral zero point is set.
+
+### PS4 Dualshock Controller
+
 ![PS4 Dualshock Controller](https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/DualShock_4.jpg/271px-DualShock_4.jpg)
 
 * Left bumper: Press and hold for manual control

--- a/config/joystick.lua
+++ b/config/joystick.lua
@@ -54,12 +54,11 @@ SpektrumDxsMapping = {
     sit_button = -1;
     stand_button = -1;
     sit_stand_axis = 4;
-    axis_scale = 32768 / 23638;
 
     x_axis = 3;
     y_axis = 2;
     r_axis = 0;
-    xyr_axes_inverted = false;
+    axis_scale = 32768 / 23638;
 
     left_bumper = 0;
     record_start_button = 0;

--- a/config/joystick.lua
+++ b/config/joystick.lua
@@ -13,3 +13,19 @@ record_cmd = "rosbag record /status /velodyne_points /scan /imu/data /jackal_vel
     " /spot/camera/right/camera_info"..
     " /spot/camera/left/camera_info"..
     " /spot/camera/back/camera_info __name:=joystick_rosbag_record&";
+
+Ps4Mapping = {
+    manual_button = 4;
+    autonomous_button = 5;
+    sit_button = 3;
+    stand_button = 0;
+    x_axis = 4;
+    y_axis = 3;
+    r_axis = 0;
+
+    left_bumper = 4;
+    record_start_button = 2;
+    record_stop_button = 1;
+};
+
+Mapping = Ps4Mapping;

--- a/config/joystick.lua
+++ b/config/joystick.lua
@@ -34,19 +34,44 @@ Ps4Mapping = {
 };
 
 SpektrumDxsMapping = {
--- Left button: button 0, also turns axis 5 from positive to negative
--- "A" switch: axis 4, 0->positive, 1->0, 2->negative
--- "D" switch: axis 6, 0->positive, 1->0, 2->negative and turns button 1 on
--- Left joystick LR: axis 0, left->positive, right->negative
--- Left joystick UpDn: axis 1, up->positive, down->negative; only active if "H" switch=0
--- "H" switch: 0->enables axis 1
--- "F" switch: 1->makes axes 0,2,3 magnitude smaller?
--- Right joystick LR: axis 2: left->positive, right->negative
--- Right joystick UpDn: axis 3: up->positive, down->negative
+--[[
+Left Side:
+    A button: button#0, also turns axis#5 from positive to negative
+        axis#5 does not appear to map to anything else
+    B switch: axis#4
+        0 -> positive value
+        1 -> zero value
+        2 -> negative value
+    D switch: axis#6
+        0 -> positive value
+        1 -> zero value
+        2 -> negative value, also toggles button#1
+    Left Joystick
+        Left-Right: axis#0
+            left -> positive
+            right -> negative
+        Up-Down: axis#1, only active if the H switch is set to 0
+            up -> positive
+            down -> negative
 
--- when the adjustment is approximately equal the sound feedback is more of a
--- high-pitch chirp than a beep
+Right Side:
+    H switch: enable/disable axis#1 joystick
+        0 -> enable
+        1 -> disable, arbitrary negative value reported
+    F switch: reduce joystick values
+        0 -> full range (-23638 to +23637 at neutral zero point)
+        1 -> reduced range (about 70%)
+    Right Joystick:
+        Left-Right: axis #2
+            left -> positive
+            right -> negative
+        Up-Down: axis#3
+            up -> positive
+            down -> negative
 
+Four Trim Sliders: adjust zero point of joysticks
+    Higher-pitch chirp at neutral zero point.
+--]]
     manual_button = -1;
     autonomous_button = -1;
     manual_autonomous_axis = 6;

--- a/config/joystick.lua
+++ b/config/joystick.lua
@@ -17,15 +17,53 @@ record_cmd = "rosbag record /status /velodyne_points /scan /imu/data /jackal_vel
 Ps4Mapping = {
     manual_button = 4;
     autonomous_button = 5;
+    manual_autonomous_axis = -1;
+
     sit_button = 3;
     stand_button = 0;
+    sit_stand_axis = -1;
+
     x_axis = 4;
     y_axis = 3;
     r_axis = 0;
+    axis_scale = -1;
 
     left_bumper = 4;
     record_start_button = 2;
     record_stop_button = 1;
 };
 
-Mapping = Ps4Mapping;
+SpektrumDxsMapping = {
+-- Left button: button 0, also turns axis 5 from positive to negative
+-- "A" switch: axis 4, 0->positive, 1->0, 2->negative
+-- "D" switch: axis 6, 0->positive, 1->0, 2->negative and turns button 1 on
+-- Left joystick LR: axis 0, left->positive, right->negative
+-- Left joystick UpDn: axis 1, up->positive, down->negative; only active if "H" switch=0
+-- "H" switch: 0->enables axis 1
+-- "F" switch: 1->makes axes 0,2,3 magnitude smaller?
+-- Right joystick LR: axis 2: left->positive, right->negative
+-- Right joystick UpDn: axis 3: up->positive, down->negative
+
+-- when the adjustment is approximately equal the sound feedback is more of a
+-- high-pitch chirp than a beep
+
+    manual_button = -1;
+    autonomous_button = -1;
+    manual_autonomous_axis = 6;
+
+    sit_button = -1;
+    stand_button = -1;
+    sit_stand_axis = 4;
+    axis_scale = 32768 / 23638;
+
+    x_axis = 3;
+    y_axis = 2;
+    r_axis = 0;
+    xyr_axes_inverted = false;
+
+    left_bumper = 0;
+    record_start_button = 0;
+    record_stop_button = 0;
+};
+
+Mapping = SpektrumDxsMapping;

--- a/joystick/joystick_driver.cc
+++ b/joystick/joystick_driver.cc
@@ -41,7 +41,7 @@
 DECLARE_int32(v);
 DEFINE_int32(idx, 0, "Joystick index");
 DEFINE_uint32(manual_button, 4, "Manual mode button");
-DEFINE_uint32(autonomous_button, 2, "Autonomous mode button");
+DEFINE_uint32(autonomous_button, 5, "Autonomous mode button");
 DEFINE_double(
     max_cmd_age, 0.1, "Maximum permissible age of autonomous command");
 

--- a/joystick/joystick_driver.cc
+++ b/joystick/joystick_driver.cc
@@ -214,7 +214,9 @@ void SetManualCommand(const vector<int32_t>& buttons,
   const float kMaxRotationSpeed = math_util::DegToRad(90);
   std_srvs::Trigger trigger_req;
   manual_cmd_.linear.x = JoystickValue(axes[CONFIG_x_axis], CONFIG_axis_scale * kMaxLinearSpeed);
-  manual_cmd_.linear.y = JoystickValue(axes[CONFIG_y_axis], CONFIG_axis_scale * kMaxLinearSpeed);
+  // The connection point of the y axis on the controller broke and it returns unstable values.
+  // Turn off y-velocity until it is fixed.
+  manual_cmd_.linear.y = JoystickValue(axes[CONFIG_y_axis], 0.0f * CONFIG_axis_scale * kMaxLinearSpeed);
   manual_cmd_.angular.z = JoystickValue(axes[CONFIG_r_axis], CONFIG_axis_scale * kMaxRotationSpeed);
 
   if (state_ == JoystickState::MANUAL) {

--- a/joystick/joystick_driver.cc
+++ b/joystick/joystick_driver.cc
@@ -47,12 +47,18 @@ DEFINE_double(
 
 DEFINE_string(config, "config/joystick.lua", "Config file");
 
+// Non-negative values indicate whether the buttons XOR axis should be used.
+// Buttons take precedence.
 CONFIG_INT(manual_button, "Mapping.manual_button");
 CONFIG_INT(autonomous_button, "Mapping.autonomous_button");
 CONFIG_INT(manual_autonomous_axis, "Mapping.manual_autonomous_axis");
+
+// Non-negative values indicate whether the buttons XOR axis should be used.
+// Buttons take precedence.
 CONFIG_INT(sit_button, "Mapping.sit_button");
 CONFIG_INT(stand_button, "Mapping.stand_button");
 CONFIG_INT(sit_stand_axis, "Mapping.sit_stand_axis");
+
 CONFIG_INT(x_axis, "Mapping.x_axis");
 CONFIG_INT(y_axis, "Mapping.y_axis");
 CONFIG_INT(r_axis, "Mapping.r_axis");


### PR DESCRIPTION
Modifies the joystick driver code to work with the Spektrum DXS Controller. These changes should retain backwards compatibility with the PS4 bluetooth controllers.

https://github.com/ut-amrl/spot_autonomy/commit/bdc1a16c8690fe5b1dbbe241971ed12caf47b057 is a temporary patch. It should be reverted once the wire for the affected axis is resoldered.